### PR TITLE
[Mercury] Reverting addition of biosample, bioproject accessions

### DIFF
--- a/mercury/Metadata.py
+++ b/mercury/Metadata.py
@@ -35,7 +35,7 @@ class Metadata:
 
   def bankit_metadata(self):
     bankit_required = ["submission_id", "collection_date", "country", "host"]
-    bankit_optional = ["isolate", "isolation_source", "biosample_accession", "bioproject_accession"]
+    bankit_optional = ["isolate", "isolation_source"]
     return bankit_required, bankit_optional
     
   def sra_metadata(self):

--- a/mercury/Table.py
+++ b/mercury/Table.py
@@ -437,7 +437,7 @@ class Table:
         bankit_metadata[column] = self.table[column]
       else:
         bankit_metadata[column] = ""
-    bankit_metadata.rename(columns={"submission_id" : "Sequence_ID", "isolate" : "Isolate", "collection_date" : "Collection_date", "country" : "Country", "host" : "Host", "isolation_source" : "Isolation_source", "biosample_accession" : "Biosample_accession", "bioproject_accession" : "Bioproject_accession"}, inplace=True)
+    bankit_metadata.rename(columns={"submission_id" : "Sequence_ID", "isolate" : "Isolate", "collection_date" : "Collection_date", "country" : "Country", "host" : "Host", "isolation_source" : "Isolation_source"}, inplace=True)
 
     self.logger.debug("TABLE:Writing BankIt metadata out to a file")
     bankit_metadata.to_csv(self.output_prefix + ".src", sep='\t', index=False)


### PR DESCRIPTION
This PR is reverting the changes adding the `biosample_accession` and `bioproject_accession` numbers from the `bankit_metadata` file. There would be issues with these as the default `{populate_with_BioSample_accession}` would be populated in the bankit `sqn` file causing issues for other Mercury users. 

Testing [here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_Hale_Sandbox/submission_history/6691c87b-9c31-4177-9511-7b5620763a9e).